### PR TITLE
Specify supported Bootstrap versions exclusively

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Turn checkboxes and radio buttons in toggle switches.",
   "main": "./dist/js/bootstrap-switch.js",
   "dependencies": {
-    "bootstrap": ">=2.3.2",
+    "bootstrap": "2.3.2 - 3",
     "jquery": ">=1.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-toggle-switch",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "description": "Turn checkboxes and radio buttons in toggle switches.",
   "main": "./dist/js/bootstrap-switch.js",


### PR DESCRIPTION
This package seems supports only Bootstrap 2 and Bootstrap 3 but in package.json Bootstrap dependency was defined as ">=2.3.2" which includes Bootstrap 4 as well. So it is better to specify Bootstrap versions exclusively by changing this version as "2.3.2 - 3" until this package supports Bootstrap 4.